### PR TITLE
Two main changes: Pass digit props through display AND give digits a NULL display ability

### DIFF
--- a/src/Digit.jsx
+++ b/src/Digit.jsx
@@ -24,9 +24,12 @@ class Digit extends React.Component {
       "6": ["a", "f", "g", "c", "d", "e"],
       "7": ["a", "b", "c"],
       "8": ["a", "b", "c", "d", "e", "f", "g"],
-      "9": ["a", "b", "c", "d", "f", "g"],
-      " ": props.nullDisplay
+      "9": ["a", "b", "c", "d", "f", "g"]
     };
+
+    if (props.nullDisplay.length != 0) {
+      this.digits[" "] = props.nullDisplay;
+    }
   }
 
   getSegment(id) {

--- a/src/Digit.jsx
+++ b/src/Digit.jsx
@@ -65,7 +65,7 @@ class Digit extends React.Component {
           strokeLinejoin: "miter"
         }}
       >
-        {Object.keys(this.segments).map(key => (
+        {Object.keys(this.segments).map(key =>
           <polygon
             key={key}
             points={this.getSegment(key)}
@@ -76,7 +76,7 @@ class Digit extends React.Component {
                 : this.props.offOpacity
             }
           />
-        ))}
+        )}
       </g>
     );
   }

--- a/src/Digit.jsx
+++ b/src/Digit.jsx
@@ -24,7 +24,8 @@ class Digit extends React.Component {
       "6": ["a", "f", "g", "c", "d", "e"],
       "7": ["a", "b", "c"],
       "8": ["a", "b", "c", "d", "e", "f", "g"],
-      "9": ["a", "b", "c", "d", "f", "g"]
+      "9": ["a", "b", "c", "d", "f", "g"],
+      " ": props.nullDisplay
     };
   }
 
@@ -61,7 +62,7 @@ class Digit extends React.Component {
           strokeLinejoin: "miter"
         }}
       >
-        {Object.keys(this.segments).map(key =>
+        {Object.keys(this.segments).map(key => (
           <polygon
             key={key}
             points={this.getSegment(key)}
@@ -72,7 +73,7 @@ class Digit extends React.Component {
                 : this.props.offOpacity
             }
           />
-        )}
+        ))}
       </g>
     );
   }

--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -22,6 +22,7 @@ class Display extends React.Component {
               onOpacity={this.props.digitProps.onOpacity}
               offOpacity={this.props.digitProps.offOpacity}
               color={this.props.digitProps.color}
+              nullDisplay={this.props.nullDisplay}
             />
           ))}
       </svg>
@@ -31,7 +32,8 @@ class Display extends React.Component {
 
 Display.defaultProps = {
   digitCount: 4,
-  value: ""
+  value: "",
+  nullDisplay: []
 };
 
 export default Display;

--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -22,7 +22,6 @@ class Display extends React.Component {
               onOpacity={this.props.digitProps.onOpacity}
               offOpacity={this.props.digitProps.offOpacity}
               color={this.props.digitProps.color}
-              nullDisplay={this.props.nullDisplay}
             />
           ))}
       </svg>
@@ -32,8 +31,7 @@ class Display extends React.Component {
 
 Display.defaultProps = {
   digitCount: 4,
-  value: "",
-  nullDisplay: []
+  value: ""
 };
 
 export default Display;

--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -14,14 +14,16 @@ class Display extends React.Component {
           .padStart(this.props.digitCount, " ")
           .split("")
           .slice(-this.props.digitCount)
-          .map((digit, key) =>
+          .map((digit, key) => (
             <Digit
               key={key}
               value={digit}
               x={key * 12}
-              color={this.props.color}
+              onOpacity={this.props.digitProps.onOpacity}
+              offOpacity={this.props.digitProps.offOpacity}
+              color={this.props.digitProps.color}
             />
-          )}
+          ))}
       </svg>
     );
   }


### PR DESCRIPTION
The use cases for these two changes are as follows:

1.) Pass digit props through display
- I wanted to be able to make changes to the opacity through sliders and other interactable components on the webpage, and I didn't see there being a way to pass these props through the Display that contains these digits.  This might be React.js unawareness on my part but I accomplished this by adding digit props to the display and then passing these props through display to the digit.

- I also refactored color so that it is a part of the digitProps object within Display

2.) NULL display ability for digits
- Added a property for a digit that is the NULL value.  That is, when the value is a space, which is the current default value for when nothing should be displayed, that can be replaced by a number.

- Use case: A timer that has 1 minute and 3 seconds left for example.  (Empty digit with no active segments is represented by "_" here.)  Instead of displaying _1:_3, the timer could display 01:03 or _1:03 depending on the properties of the displays within.

- Change the NULL display prop in the Display, and this affects the child Digits within.

Let me know if you have any questions!
Thanks,
Alex