### PR TITLE
Add `strokeColor` prop

### DIFF
--- a/src/Colon.jsx
+++ b/src/Colon.jsx
@@ -22,7 +22,7 @@ class Colon extends React.Component {
           ])}
           style={{
             fillRule: "evenodd",
-            stroke: "#fff",
+            stroke: this.props.strokeColour,
             strokeWidth: 0.25,
             strokeOpacity: 1,
             strokeLinecap: "butt",
@@ -58,6 +58,7 @@ Colon.defaultProps = {
   onOpacity: 1,
   offOpacity: 0.15,
   color: "red",
+  strokeColor: "#fff",
   x: 0,
   y: 0
 };

--- a/src/Digit.jsx
+++ b/src/Digit.jsx
@@ -54,14 +54,14 @@ class Digit extends React.Component {
         ])}
         style={{
           fillRule: "evenodd",
-          stroke: "#fff",
+          stroke: this.props.strokeColor,
           strokeWidth: 0.25,
           strokeOpacity: 1,
           strokeLinecap: "butt",
           strokeLinejoin: "miter"
         }}
       >
-        {Object.keys(this.segments).map(key =>
+        {Object.keys(this.segments).map(key => (
           <polygon
             key={key}
             points={this.getSegment(key)}
@@ -72,7 +72,7 @@ class Digit extends React.Component {
                 : this.props.offOpacity
             }
           />
-        )}
+        ))}
       </g>
     );
   }
@@ -83,6 +83,7 @@ Digit.defaultProps = {
   onOpacity: 1,
   offOpacity: 0.15,
   color: "red",
+  strokeColor: "#fff",
   x: 0,
   y: 0
 };

--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -20,6 +20,7 @@ class Display extends React.Component {
               value={digit}
               x={key * 12}
               color={this.props.color}
+              strokeColor={this.props.strokeColor}
             />
           )}
       </svg>
@@ -29,7 +30,8 @@ class Display extends React.Component {
 
 Display.defaultProps = {
   digitCount: 4,
-  value: ""
+  value: "",
+  strokeColor: "#fff",
 };
 
 export default Display;


### PR DESCRIPTION
Inspired by [tdukart's fork](https://github.com/tdukart/seven-segment-display) I added a `strokeColor` prop to `Display`, `Digit`, and `Colon`. I'm using the clock on a black background so this was necessary to remove the white lines.